### PR TITLE
Fixed a bug where the daily script process exited too early

### DIFF
--- a/sachi.js
+++ b/sachi.js
@@ -51,9 +51,13 @@ const rankedData = [
   'gearscore',
   'commendation',
   'clanexp',
+  'cxp',
   'clanexp24h',
+  'cxp24h',
   'clanexp7d',
-  'clanexp30d'
+  'cxp7d',
+  'clanexp30d',
+  'cxp30d'
 ];
 
 // Possible parameters for !platform

--- a/scripts/daily_exp_snapshots.js
+++ b/scripts/daily_exp_snapshots.js
@@ -19,31 +19,41 @@ pool.query("SELECT * FROM users").then(async function(response){
   if( response.length > 0 ) {
     for(var i=0; i<response.length; i++) {
       agent = response[i];
+      let curI = i;
 
       if( useTrackerGG )
         agent_data = await getPlayerData(agent.uplay_id, agent.platform, agent.agent_name);
       else
         agent_data = await getPlayerData(agent.uplay_id);
 
+      let queryPromise;
       if( lodash.isEmpty(agent_data) == false ) {
 
-        pool.query("INSERT INTO daily_exp_snapshots (uplay_id, clan_exp, pve_exp, dz_exp, date_added) VALUES (?, ?, ?, ?, ?)", [
+        queryPromise = pool.query("INSERT INTO daily_exp_snapshots (uplay_id, clan_exp, pve_exp, dz_exp, date_added) VALUES (?, ?, ?, ?, ?)", [
           agent.uplay_id,
           agent_data.xp_clan,
           agent_data.xp_ow,
           agent_data.xp_dz,
           moment().format('YYYY-M-D HH:mm:ss')
-        ]);
+        ]).then((res) => {
+		helper.printStatus("Created daily exp record for " + agent_data.name);
+	      helper.printStatus( curI+1 + "/" + response.length );
+		return res;
+	});
 
-        helper.printStatus("Created daily exp record for " + agent_data.name);
-        helper.printStatus( i+1 + "/" + response.length );
       }
       else {
-        pool.query("DELETE FROM users WHERE id = ?", [agent.id]);
-        helper.printStatus("Deleted user id: " + agent.id);
+        queryPromise = pool.query("DELETE FROM users WHERE id = ?", [agent.id]).then((res) => {
+          helper.printStatus("Deleted user id: " + agent.id);
+		return res;
+	});
+      }
+      if (i == response.length - 1) {
+        queryPromise.then((res) => {
+          process.exit();
+        });
       }
     }
-    process.exit();
   }
 })
 


### PR DESCRIPTION
Despite being in the log, often the last entry of both `users` and `server_agents` were not present in the final `daily_exp_snapshots`.

The bug was because of a `process.exit()` being called too early, without waiting for an async SQL request to finish. 